### PR TITLE
Fixing dictionary detection for absolute paths

### DIFF
--- a/pkg/dictionary/dictionary.go
+++ b/pkg/dictionary/dictionary.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 
 	"github.com/pkg/errors"
@@ -13,8 +12,7 @@ import (
 const commentPrefix = "#"
 
 func NewDictionaryFrom(path string, doer Doer) ([]string, error) {
-	_, err := url.ParseRequestURI(path)
-	if err != nil {
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return newDictionaryFromLocalFile(path)
 	}
 

--- a/pkg/dictionary/dictionary_integration_test.go
+++ b/pkg/dictionary/dictionary_integration_test.go
@@ -3,6 +3,7 @@ package dictionary_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,6 +13,21 @@ import (
 
 func TestDictionaryFromFile(t *testing.T) {
 	entries, err := dictionary.NewDictionaryFrom("testdata/dict.txt", &http.Client{})
+	assert.NoError(t, err)
+
+	expectedValue := []string{
+		"home",
+		"home/index.php",
+		"blabla",
+	}
+	assert.Equal(t, expectedValue, entries)
+}
+
+func TestDictionaryFromAbsolutePath(t *testing.T) {
+	path, err := filepath.Abs("testdata/dict.txt")
+	assert.NoError(t, err)
+
+	entries, err := dictionary.NewDictionaryFrom(path, &http.Client{})
 	assert.NoError(t, err)
 
 	expectedValue := []string{
@@ -37,6 +53,7 @@ func TestNewDictionaryFromRemoteFile(t *testing.T) {
 /about
 /contacts
 something
+potato
 `
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(dict))
@@ -52,6 +69,7 @@ something
 		"/about",
 		"/contacts",
 		"something",
+		"potato",
 	}
 	assert.Equal(t, expectedValue, entries)
 }


### PR DESCRIPTION
Fixing a bug that would cause the scanner to try and fetch the dictionary from remote when provided with an absolute path