### PR TITLE
Changing url joining to respect ending slashes

### DIFF
--- a/pkg/cmd/root_integration_test.go
+++ b/pkg/cmd/root_integration_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const socks5TestServerHost = "127.0.0.1:8899"
-
 func TestRootCommand(t *testing.T) {
 	logger, _ := test.NewLogger()
 
@@ -50,7 +48,7 @@ func TestVersionCommand(t *testing.T) {
 
 func executeCommand(root *cobra.Command, args ...string) (c *cobra.Command, output string, err error) {
 	buf := new(bytes.Buffer)
-	root.SetOutput(buf)
+	root.SetOut(buf)
 
 	a := []string{""}
 	os.Args = append(a, args...)

--- a/pkg/cmd/testdata/dict2.txt
+++ b/pkg/cmd/testdata/dict2.txt
@@ -1,0 +1,4 @@
+test/
+home
+home/index.php
+blabla

--- a/pkg/common/urlpath/join.go
+++ b/pkg/common/urlpath/join.go
@@ -1,0 +1,22 @@
+package urlpath
+
+import (
+	"path"
+	"strings"
+)
+
+// Join joins any number of path elements into a single path, adding a
+// separating slash if necessary. The result is Cleaned; in particular,
+// all empty strings are ignored.
+// If the last element end in a slash it will preserve it
+func Join(elem ...string) string {
+	joined := path.Join(elem...)
+
+	last := elem[len(elem)-1]
+
+	if strings.HasSuffix(last, "/") && !strings.HasSuffix(joined, "/") {
+		joined = joined + "/"
+	}
+
+	return joined
+}

--- a/pkg/common/urlpath/join_test.go
+++ b/pkg/common/urlpath/join_test.go
@@ -1,0 +1,67 @@
+package urlpath_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stefanoj3/dirstalk/pkg/common/urlpath"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoin(t *testing.T) {
+	testCases := []struct {
+		input          []string
+		expectedOutput string
+	}{
+		{
+			input:          []string{"/home"},
+			expectedOutput: "/home",
+		},
+		{
+			input:          []string{"/home/"},
+			expectedOutput: "/home/",
+		},
+		{
+			input:          []string{"/home/", "test"},
+			expectedOutput: "/home/test",
+		},
+		{
+			input:          []string{"/home/", "/test"},
+			expectedOutput: "/home/test",
+		},
+		{
+			input:          []string{"/home/", "/test/"},
+			expectedOutput: "/home/test/",
+		},
+		{
+			input:          []string{"/home", "/test/"},
+			expectedOutput: "/home/test/",
+		},
+		{
+			input:          []string{"/home", "test/"},
+			expectedOutput: "/home/test/",
+		},
+		{
+			input:          []string{"/home", "test"},
+			expectedOutput: "/home/test",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		scenario := fmt.Sprintf(
+			"Input: `%s`, Expected output: `%s`",
+			strings.Join(tc.input, ","),
+			tc.expectedOutput,
+		)
+
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+
+			output := urlpath.Join(tc.input...)
+
+			assert.Equal(t, tc.expectedOutput, output)
+		})
+	}
+}

--- a/pkg/scan/producer/reproducer.go
+++ b/pkg/scan/producer/reproducer.go
@@ -1,9 +1,9 @@
 package producer
 
 import (
-	"path"
 	"sync"
 
+	"github.com/stefanoj3/dirstalk/pkg/common/urlpath"
 	"github.com/stefanoj3/dirstalk/pkg/pathutil"
 	"github.com/stefanoj3/dirstalk/pkg/scan"
 )
@@ -62,7 +62,7 @@ func (r *ReProducer) buildReproducer() func(result scan.Result) <-chan scan.Targ
 			for target := range r.producer.Produce() {
 				newTarget := result.Target
 				newTarget.Depth--
-				newTarget.Path = path.Join(newTarget.Path, target.Path)
+				newTarget.Path = urlpath.Join(newTarget.Path, target.Path)
 				newTarget.Method = target.Method
 
 				resultChannel <- newTarget

--- a/pkg/scan/scanner.go
+++ b/pkg/scan/scanner.go
@@ -3,11 +3,11 @@ package scan
 import (
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stefanoj3/dirstalk/pkg/common/urlpath"
 )
 
 // Target represents the target to scan
@@ -128,6 +128,7 @@ func normalizeBaseURL(baseURL url.URL) url.URL {
 }
 
 func buildURL(baseURL url.URL, target Target) url.URL {
-	baseURL.Path = path.Join(baseURL.Path, target.Path)
+	baseURL.Path = urlpath.Join(baseURL.Path, target.Path)
+
 	return baseURL
 }


### PR DESCRIPTION
Solving https://github.com/stefanoj3/dirstalk/issues/39

Now if the dictionary contains an entry entry ending with a `/`, when this entry is used as the last part of the path, the `/` will be kept.

This means that having:
```
home
home/
```
in your dictionary will result in 2 different entries.

Useful when the webserver you are calling might make a difference between trailing slash vs no trailing slash.