### PR TITLE
Fixing scenario in which using a non-existing file would return an error about schema

### DIFF
--- a/pkg/dictionary/dictionary.go
+++ b/pkg/dictionary/dictionary.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -12,11 +13,11 @@ import (
 const commentPrefix = "#"
 
 func NewDictionaryFrom(path string, doer Doer) ([]string, error) {
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		return newDictionaryFromLocalFile(path)
+	if strings.HasPrefix(path, "http") {
+		return newDictionaryFromRemoteFile(path, doer)
 	}
 
-	return newDictionaryFromRemoteFile(path, doer)
+	return newDictionaryFromLocalFile(path)
 }
 
 func newDictionaryFromLocalFile(path string) ([]string, error) {

--- a/pkg/dictionary/dictionary_integration_test.go
+++ b/pkg/dictionary/dictionary_integration_test.go
@@ -65,6 +65,8 @@ func TestDictionaryFromFileWithInvalidPath(t *testing.T) {
 	d, err := dictionary.NewDictionaryFrom("testdata/gibberish_nonexisting_file", &http.Client{})
 	assert.Error(t, err)
 	assert.Nil(t, d)
+
+	assert.Contains(t, err.Error(), "unable to open")
 }
 
 func TestNewDictionaryFromRemoteFile(t *testing.T) {


### PR DESCRIPTION
### Description

I'm fixing an issue that causes the scan command to return an "invalid schema" error when a non-existing file is provided as a dictionary.