### PR TITLE
New feature: filter out http 20x responses with empty body

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -86,6 +86,11 @@ func scanConfigFromCmd(cmd *cobra.Command) (*scan.Config, error) {
 		return nil, errors.Wrapf(err, failedToReadPropertyError, flagShouldSkipSSLCertificatesValidation)
 	}
 
+	c.IgnoreEmpty20xResponses, err = cmd.Flags().GetBool(flagIgnore20xWithEmptyBody)
+	if err != nil {
+		return nil, errors.Wrapf(err, failedToReadPropertyError, flagIgnore20xWithEmptyBody)
+	}
+
 	return c, nil
 }
 

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -24,6 +24,8 @@ const (
 	flagScanResultOutput                    = "out"
 	flagShouldSkipSSLCertificatesValidation = "no-check-certificate"
 
+	flagIgnore20xWithEmptyBody              = "ignore-empty-body"
+
 	// Generate dictionary flags.
 	flagDictionaryGenerateOutput           = "out"
 	flagDictionaryGenerateOutputShort      = "o"

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -133,6 +133,12 @@ func NewScanCommand(logger *logrus.Logger) *cobra.Command {
 		"to skip checking the validity of SSL certificates",
 	)
 
+	cmd.Flags().Bool(
+		flagIgnore20xWithEmptyBody,
+		false,
+		"ignore HTTP 20x responses with empty body",
+	)
+
 	return cmd
 }
 
@@ -257,7 +263,7 @@ func buildScanner(cnf *scan.Config, dict []string, u *url.URL, logger *logrus.Lo
 	targetProducer := producer.NewDictionaryProducer(cnf.HTTPMethods, dict, cnf.ScanDepth)
 	reproducer := producer.NewReProducer(targetProducer)
 
-	resultFilter := filter.NewHTTPStatusResultFilter(cnf.HTTPStatusesToIgnore)
+	resultFilter := filter.NewHTTPStatusResultFilter(cnf.HTTPStatusesToIgnore, cnf.IgnoreEmpty20xResponses)
 
 	scannerClient, err := buildScannerClient(cnf, u)
 	if err != nil {

--- a/pkg/scan/config.go
+++ b/pkg/scan/config.go
@@ -22,4 +22,5 @@ type Config struct {
 	Headers                             map[string]string
 	Out                                 string
 	ShouldSkipSSLCertificatesValidation bool
+	IgnoreEmpty20xResponses             bool
 }

--- a/pkg/scan/filter/http.go
+++ b/pkg/scan/filter/http.go
@@ -4,20 +4,25 @@ import (
 	"github.com/stefanoj3/dirstalk/pkg/scan"
 )
 
-func NewHTTPStatusResultFilter(httpStatusesToIgnore []int) HTTPStatusResultFilter {
+func NewHTTPStatusResultFilter(httpStatusesToIgnore []int, ignoreEmptyBody bool) HTTPStatusResultFilter {
 	httpStatusesToIgnoreMap := make(map[int]struct{}, len(httpStatusesToIgnore))
 	for _, statusToIgnore := range httpStatusesToIgnore {
 		httpStatusesToIgnoreMap[statusToIgnore] = struct{}{}
 	}
 
-	return HTTPStatusResultFilter{httpStatusesToIgnoreMap: httpStatusesToIgnoreMap}
+	return HTTPStatusResultFilter{httpStatusesToIgnoreMap: httpStatusesToIgnoreMap, ignoreEmptyBody: ignoreEmptyBody}
 }
 
 type HTTPStatusResultFilter struct {
 	httpStatusesToIgnoreMap map[int]struct{}
+	ignoreEmptyBody bool
 }
 
 func (f HTTPStatusResultFilter) ShouldIgnore(result scan.Result) bool {
+	if f.ignoreEmptyBody && result.StatusCode / 100 == 2 && result.ContentLength == 0 {
+		return true
+	}
+
 	_, found := f.httpStatusesToIgnoreMap[result.StatusCode]
 
 	return found

--- a/pkg/scan/filter/http_test.go
+++ b/pkg/scan/filter/http_test.go
@@ -47,14 +47,14 @@ func TestHTTPStatusResultFilter(t *testing.T) {
 		t.Run(scenario, func(t *testing.T) {
 			t.Parallel()
 
-			actual := filter.NewHTTPStatusResultFilter(tc.statusCodesToIgnore).ShouldIgnore(tc.result)
+			actual := filter.NewHTTPStatusResultFilter(tc.statusCodesToIgnore, false).ShouldIgnore(tc.result)
 			assert.Equal(t, tc.expectedResult, actual)
 		})
 	}
 }
 
 func TestHTTPStatusResultFilterShouldWorkConcurrently(_ *testing.T) {
-	sut := filter.NewHTTPStatusResultFilter(nil)
+	sut := filter.NewHTTPStatusResultFilter(nil, false)
 
 	wg := sync.WaitGroup{}
 

--- a/pkg/scan/output/saver_integration_test.go
+++ b/pkg/scan/output/saver_integration_test.go
@@ -55,7 +55,7 @@ func TestFileSaverShouldWriteResults(t *testing.T) {
 
 	assert.NoError(t, file.Close())
 
-	expected := `{"Target":{"Path":"","Method":"","Depth":0},"StatusCode":0,"URL":{"Scheme":"","Opaque":"","User":null,"Host":"","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":"","RawFragment":""}}
+	expected := `{"Target":{"Path":"","Method":"","Depth":0},"StatusCode":0,"URL":{"Scheme":"","Opaque":"","User":null,"Host":"","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":"","RawFragment":""},"ContentLength":0}
 `
 	assert.Equal(
 		t,

--- a/pkg/scan/scanner.go
+++ b/pkg/scan/scanner.go
@@ -24,6 +24,7 @@ type Result struct {
 	Target     Target
 	StatusCode int
 	URL        url.URL
+	ContentLength int64
 }
 
 // NewResult creates a new instance of the Result entity based on the Target and Response.
@@ -32,6 +33,7 @@ func NewResult(target Target, response *http.Response) Result {
 		Target:     target,
 		StatusCode: response.StatusCode,
 		URL:        *response.Request.URL,
+		ContentLength: response.ContentLength,
 	}
 }
 

--- a/pkg/scan/scanner_integration_test.go
+++ b/pkg/scan/scanner_integration_test.go
@@ -23,7 +23,7 @@ func TestScanningWithEmptyProducerWillProduceNoResults(t *testing.T) {
 		c,
 		prod,
 		producer.NewReProducer(prod),
-		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}),
+		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}, false),
 		logger,
 	)
 
@@ -65,7 +65,7 @@ func TestScannerWillLogAnErrorWithInvalidDictionary(t *testing.T) {
 		c,
 		prod,
 		producer.NewReProducer(prod),
-		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}),
+		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}, false),
 		logger,
 	)
 
@@ -120,7 +120,7 @@ func TestScannerWillNotRedirectIfStatusCodeIsInvalid(t *testing.T) {
 		c,
 		prod,
 		producer.NewReProducer(prod),
-		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}),
+		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}, false),
 		logger,
 	)
 
@@ -191,7 +191,7 @@ func TestScannerWillChangeMethodForRedirect(t *testing.T) {
 		c,
 		prod,
 		producer.NewReProducer(prod),
-		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}),
+		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}, false),
 		logger,
 	)
 
@@ -260,7 +260,7 @@ func TestScannerWhenOutOfDepthWillNotFollowRedirect(t *testing.T) {
 		c,
 		prod,
 		producer.NewReProducer(prod),
-		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}),
+		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}, false),
 		logger,
 	)
 
@@ -327,7 +327,7 @@ func TestScannerWillSkipRedirectWhenLocationHostIsDifferent(t *testing.T) {
 		c,
 		prod,
 		producer.NewReProducer(prod),
-		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}),
+		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}, false),
 		logger,
 	)
 
@@ -387,7 +387,7 @@ func TestScannerWillIgnoreRequestRedundantError(t *testing.T) {
 		c,
 		prod,
 		producer.NewReProducer(prod),
-		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}),
+		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}, false),
 		logger,
 	)
 
@@ -442,7 +442,7 @@ func TestCanCancelScanUsingContext(t *testing.T) {
 		c,
 		prod,
 		producer.NewReProducer(prod),
-		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}),
+		filter.NewHTTPStatusResultFilter([]int{http.StatusNotFound}, false),
 		logger,
 	)
 


### PR DESCRIPTION
I came across a web server recently that returned HTTP 200 for pretty much everything. The responses had an empty body. In this setup Dirstalk simply never completed the scanning as it tried entering the hits as subpaths.
No idea if this is typical or not and whether it worth having the feature/workaround I implemented, but here you go.
It would be cool if one could define a dynamic filter over the command line, e.g. by leveraging CEL or similar.

(And props for this tool, it is awesome!)